### PR TITLE
Indicate UTF-8 instead of letting browsers guess.

### DIFF
--- a/about.hbs
+++ b/about.hbs
@@ -1,6 +1,8 @@
+<!DOCTYPE html>
 <html>
 
 <head>
+    <meta charset="utf-8">
     <style>
         @media (prefers-color-scheme: dark) {
             body {


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Indicate UTF-8 instead of letting browsers guess.

Since I'm using HTML5 style, also indicate HTML5 with `<!DOCTYPE html>`

Bacterius from Discord confused my local programming channel when UTF-8 encoded copyright symbols (©) found in popular licenses such as rdrand 0.4.0's MIT license were misrendered, gaining an extra accented A (Â©).  But not always!

This turned out to be his browser (Chrome) incorrectly guessing the locale was windows-1252 or similar.  Since Rust strings are all supposed to be UTF-8 *anyways*, I think it's safe to claim the output is UTF-8 as well.

If there do happen to be license files with other encodings, translation 'should' happen when first loaded - or better yet, the files themselves should be converted.

### Related Issues

None found

### Not Changed

I considered suggesting `<html lang="en">` as well, although language autodetection is much less likely to go wrong - and `"en"` might even be incorrect if there's ever a lot of licenses written in, say, Japanese, in some corners of the rust ecosystem.  Plus language misdetection shouldn't cause rendering bugs.

### Unrelated Chatter

Nice crate!  I've created [some proc macros](https://github.com/MaulingMonkey/lies) wrapping cargo-about to make license text trivial to embed in command line applications.  It's also dual `MIT OR Apache-2.0` licensed, so feel free to ~~steal~~ *upstream* any parts of it you find interesting ;).

Bacterius also suggested maybe adding the ability to approve licenses via Cargo.toml to reduce the amount of file clutter.  It does have a `[metadata]` section that could be used for exactly this kind of thing, although I don't mind one way or the other personally:

https://doc.rust-lang.org/cargo/reference/manifest.html#the-metadata-table-optional
https://docs.rs/cargo_metadata/0.9.1/cargo_metadata/struct.Package.html#structfield.metadata

There's also been some chatter about embedding licenses for the Rust stdlib.  I actually did some work on enumerating stdlib crates (when stdlib src is installed/available) for licensing information myself before I realized cargo-about existed - let me know if you'd be interested in me trying to extend cargo-about with some of that code.  (No promises I'll make the time thought!)