### PR TITLE
Fix config search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [#20](https://github.com/EmbarkStudios/cargo-about/pull/20) Fewer files are now scanned for license information
 - [#21](https://github.com/EmbarkStudios/cargo-about/pull/21) Pipes in the file system are now ignored on unix systems
+- [#23](https://github.com/EmbarkStudios/cargo-about/pull/23) Fixes searching for the `about.toml` configuration file
 
 ## [0.1.0] - 2019-12-06
-
 
 ## [0.0.1] - 2019-11-07
 ### Added

--- a/src/cargo-about/main.rs
+++ b/src/cargo-about/main.rs
@@ -168,7 +168,7 @@ fn main() {
     match real_main() {
         Ok(_) => {}
         Err(e) => {
-            log::error!("{}", e);
+            log::error!("{:#}", e);
             std::process::exit(1);
         }
     }

--- a/src/cargo-about/main.rs
+++ b/src/cargo-about/main.rs
@@ -82,9 +82,16 @@ fn load_config(manifest_path: &Path) -> Result<cargo_about::licenses::config::Co
     // cases where eg in a workspace there is a top-level about.toml
     // but the user is only getting a listing for a particular crate from it
     while let Some(p) = parent {
-        if !p.join("Cargo.toml").exists() {
-            break;
-        }
+        // We _could_ limit ourselves to only directories that also have a Cargo.toml
+        // in them, but there could be cases where someone has multiple
+        // rust projects in subdirectories with a single top level about.toml that is
+        // used across all of them, we could also introduce a metadata entry for the
+        // relative path of the about.toml to use for the crate/workspace
+
+        // if !p.join("Cargo.toml").exists() {
+        //     parent = p.parent();
+        //     continue;
+        // }
 
         let about_toml = p.join("about.toml");
 
@@ -99,6 +106,7 @@ fn load_config(manifest_path: &Path) -> Result<cargo_about::licenses::config::Co
         parent = p.parent();
     }
 
+    log::warn!("no 'about.toml' found, falling back to default configuration");
     Ok(cargo_about::licenses::config::Config::default())
 }
 


### PR DESCRIPTION
Previously, cargo-about would search up from the manifest path to find an `about.toml` to use for configuration, but it would use the default config if it hit a directory that didn't have a Cargo.toml in it, it now doesn't care about that, and will continue searching parents until there are none. It will also print a warning when no config is found and it falls back to the default configuration.