### PR TITLE
[ci] Switch to use cargo-deny GitHub action

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -59,72 +59,57 @@ jobs:
           command: test
           args: --release
 
-  # Remove this check if you don't use cargo-deny in the repo
   deny-check:
-    name: cargo-deny check
+    name: cargo-deny
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: download cargo-deny
-      shell: bash
-      env:
-        DVS: "0.4.0"
-        DREPO: EmbarkStudios/cargo-deny
-        TARGET: x86_64-unknown-linux-musl
-      run: |
-        temp_archive=$(mktemp --suffix=.tar.gz)
-        curl -L --output "$temp_archive" https://github.com/$DREPO/releases/download/$DVS/cargo-deny-$DVS-$TARGET.tar.gz
-
-        tar -xzvf "$temp_archive" -C . --strip-components=1 --wildcards "*/cargo-deny"
-    - name: cargo-deny check licenses
-      run: ./cargo-deny -L debug check license
-    - name: cargo-deny check bans
-      run: ./cargo-deny -L debug check ban
+      - uses: actions/checkout@v1
+      - uses: EmbarkStudios/cargo-deny-action@master # we use latest master as this is our own tool that we maintain
 
   publish-check:
     name: Publish Check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
-    - name: cargo fetch
-      uses: actions-rs/cargo@v1
-      with:
-        command: fetch
-    - name: cargo publish
-      uses: actions-rs/cargo@v1
-      with:
-        command: publish
-        args: --dry-run
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: cargo fetch
+        uses: actions-rs/cargo@v1
+        with:
+          command: fetch
+      - name: cargo publish
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: --dry-run
 
   publish:
     name: Publish
-    needs: [test, publish-check]
+    needs: [test, deny-check, publish-check]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
-    - name: cargo fetch
-      uses: actions-rs/cargo@v1
-      with:
-        command: fetch
-    - name: cargo publish
-      uses: actions-rs/cargo@v1
-      env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-      with:
-        command: publish
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: cargo fetch
+        uses: actions-rs/cargo@v1
+        with:
+          command: fetch
+      - name: cargo publish
+        uses: actions-rs/cargo@v1
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        with:
+          command: publish
 
   release:
     name: Release
-    needs: [test]
+    needs: [test, deny-check]
     if: startsWith(github.ref, 'refs/tags/')
     strategy:
       matrix:
@@ -196,6 +181,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           draft: true
-          files: 'cargo-about*'
+          files: "cargo-about*"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This also upgrades from cargo-deny 0.4.0 to 0.4.2.

This uses master version of the action, but we should switch soon to a stable v1 of it. But helpful to use master to start with to help stabilize the action.

Also fixed that the publish and release steps didn't require that cargo-deny was successful.