### PR TITLE
Add missing .vscode/settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": true,
+}


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

[Embark Guidelines](https://github.com/EmbarkStudios/rust-ecosystem/blob/main/guidelines.md#development-environments) state:

> As we want to [run rustfmt on save](https://github.com/EmbarkStudios/rust-ecosystem/blob/main/guidelines.md#001---run-rustfmt-on-save), all of our repos should have a `.vscode/settings.json` with:
> ```json
> {
>     "editor.formatOnSave": true,
> }
> ```

But this file is missing from cargo-about.

### Related Issues

Closes "Missing .vscode/settings.json" https://github.com/EmbarkStudios/cargo-about/issues/147
