### PR TITLE
Introduce `--workspace`

### DIFF
--- a/src/cargo-about/main.rs
+++ b/src/cargo-about/main.rs
@@ -58,6 +58,9 @@ Possible values:
     /// current crate or workspace in the current working directory
     #[structopt(short, long = "manifest-path", parse(from_os_str))]
     manifest_path: Option<PathBuf>,
+    /// Scan licenses for the entire workspace, not just the active package
+    #[structopt(long)]
+    workspace: bool,
     #[structopt(subcommand)]
     cmd: Command,
 }
@@ -159,6 +162,7 @@ fn real_main() -> Result<(), Error> {
                 args.no_default_features,
                 args.all_features,
                 args.features.clone(),
+                args.workspace,
                 &cfg,
             )
         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ pub fn get_all_crates(
     no_default_features: bool,
     all_features: bool,
     features: Vec<String>,
+    workspace: bool,
     cfg: &licenses::config::Config,
 ) -> Result<Krates, Error> {
     let mut mdc = krates::Cmd::new();
@@ -60,6 +61,10 @@ pub fn get_all_crates(
     mdc.features(features);
 
     let mut builder = krates::Builder::new();
+
+    if workspace {
+        builder.workspace(true);
+    }
 
     if cfg.ignore_build_dependencies {
         builder.ignore_kind(krates::DepKind::Build, krates::Scope::All);


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This adds a new command line flag, `--workspace`, allowing you to enumerate the licenses used by an entire workspace, even in the presence of a package inside the root of the workspace.

### Related Issues

Closes https://github.com/EmbarkStudios/cargo-about/issues/151 which rambles on about reasons/alternatives
