### PR TITLE
Sort same-id licenses by used_by crate name

### DIFF
--- a/src/cargo-about/generate.rs
+++ b/src/cargo-about/generate.rs
@@ -212,6 +212,7 @@ fn generate(
             lic.used_by.sort_by(|a, b| a.krate.id.cmp(&b.krate.id));
         }
 
+        licenses.sort_by(|a, b| a.used_by[0].krate.name.cmp(&b.used_by[0].krate.name));
         licenses.sort_by(|a, b| a.id.cmp(&b.id));
         licenses
     };

--- a/src/cargo-about/generate.rs
+++ b/src/cargo-about/generate.rs
@@ -212,7 +212,7 @@ fn generate(
             lic.used_by.sort_by(|a, b| a.krate.id.cmp(&b.krate.id));
         }
 
-        licenses.sort_by(|a, b| a.used_by[0].krate.name.cmp(&b.used_by[0].krate.name));
+        licenses.sort_by(|a, b| a.used_by[0].krate.id.cmp(&b.used_by[0].krate.id));
         licenses.sort_by(|a, b| a.id.cmp(&b.id));
         licenses
     };


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

If you have a bunch of `LICENSE-MIT` files with different copyright notices, you'll get a long list of licenses where `.id == "MIT"`.  While there does appear to be some kind of stable order to these licenses, sorting by crate name within a string of near-identical licenses seems saner.

That said, this may cause significant diffs to existing license files, so I'm not entirely sure if this is a good change to suggest.

### Related Issues

None
