### PR TITLE
Update Cargo.toml to reflect Cargo.lock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,15 +28,15 @@ anyhow = "1.0"
 askalono = "0.4"
 chrono = "0.4"
 fern = "0.6"
-handlebars = { version = "3.2.1", features = ["dir_source"] }
+handlebars = { version = "3.5.5", features = ["dir_source"] }
 ignore = "0.4"
 krates = "0.7"
 license = "1.1"
 log = "0.4"
-rayon = "1.3"
+rayon = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-smallvec = "1.2"
+smallvec = "1.6"
 spdx = "0.4"
 structopt = "0.3"
 toml = "0.5"


### PR DESCRIPTION
### Checklist

* [X] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

`Cargo.lock` is already set to updated versions e.g. `smallvec = "1.6.1` but the `Cargo.toml` has it at `smallvec = ^1.2` which [should pull in `1.6.1`](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#caret-requirements) but dep.rs seems to complain still...
*Edit:* I guess there hasn't been a release to crates.io using smallvec `1.6.1` so thats why it's still upset :facepalm: 

Related: should I just set handlebars to a `MAJOR.MINOR` format like (most of) the rest or was there a reason for including `PATCH`? Should I do the same for `mimalloc`?

### Related Issues

