### PR TITLE
Move generate options to generate subcmd

### DIFF
--- a/src/cargo-about/init.rs
+++ b/src/cargo-about/init.rs
@@ -23,7 +23,6 @@ pub fn cmd(args: Args) -> Result<(), Error> {
         let handlebars_path = root_path.join("about.hbs");
         let write_handlebars = !handlebars_path.is_file() || args.overwrite;
         if write_handlebars {
-            println!("WRITE");
             fs::write(handlebars_path, DEFAULT_HBS)?;
         }
     }

--- a/src/cargo-about/main.rs
+++ b/src/cargo-about/main.rs
@@ -69,8 +69,7 @@
 // END - Embark standard lints v0.4
 #![allow(clippy::exit)]
 
-use anyhow::{anyhow, bail, Context, Error};
-use std::path::{Path, PathBuf};
+use anyhow::Context as _;
 use structopt::StructOpt;
 
 mod generate;
@@ -88,9 +87,9 @@ enum Command {
     Init(init::Args),
 }
 
-fn parse_level(s: &str) -> Result<log::LevelFilter, Error> {
+fn parse_level(s: &str) -> anyhow::Result<log::LevelFilter> {
     s.parse::<log::LevelFilter>()
-        .map_err(|e| anyhow!("failed to parse level '{}': {}", s, e))
+        .with_context(|| format!("failed to parse level '{}'", s))
 }
 
 #[derive(Debug, StructOpt)]
@@ -113,22 +112,6 @@ Possible values:
 * trace"
     )]
     log_level: log::LevelFilter,
-    /// Space-separated list of features to activate
-    #[structopt(long)]
-    features: Vec<String>,
-    /// Activate all available features
-    #[structopt(long)]
-    all_features: bool,
-    /// Do not activate the `default` feature
-    #[structopt(long)]
-    no_default_features: bool,
-    /// The path of the Cargo.toml for the root crate, defaults to the
-    /// current crate or workspace in the current working directory
-    #[structopt(short, long = "manifest-path", parse(from_os_str))]
-    manifest_path: Option<PathBuf>,
-    /// Scan licenses for the entire workspace, not just the active package
-    #[structopt(long)]
-    workspace: bool,
     #[structopt(subcommand)]
     cmd: Command,
 }
@@ -159,42 +142,7 @@ fn setup_logger(level: log::LevelFilter) -> Result<(), fern::InitError> {
     Ok(())
 }
 
-fn load_config(manifest_path: &Path) -> Result<cargo_about::licenses::config::Config, Error> {
-    let mut parent = manifest_path.parent();
-
-    // Move up directories until we find an about.toml, to handle
-    // cases where eg in a workspace there is a top-level about.toml
-    // but the user is only getting a listing for a particular crate from it
-    while let Some(p) = parent {
-        // We _could_ limit ourselves to only directories that also have a Cargo.toml
-        // in them, but there could be cases where someone has multiple
-        // rust projects in subdirectories with a single top level about.toml that is
-        // used across all of them, we could also introduce a metadata entry for the
-        // relative path of the about.toml to use for the crate/workspace
-
-        // if !p.join("Cargo.toml").exists() {
-        //     parent = p.parent();
-        //     continue;
-        // }
-
-        let about_toml = p.join("about.toml");
-
-        if about_toml.exists() {
-            let contents = std::fs::read_to_string(&about_toml)?;
-            let cfg = toml::from_str(&contents)?;
-
-            log::info!("loaded config from {}", about_toml.display());
-            return Ok(cfg);
-        }
-
-        parent = p.parent();
-    }
-
-    log::warn!("no 'about.toml' found, falling back to default configuration");
-    Ok(cargo_about::licenses::config::Config::default())
-}
-
-fn real_main() -> Result<(), Error> {
+fn real_main() -> anyhow::Result<()> {
     let args = Opts::from_iter({
         std::env::args().enumerate().filter_map(|(i, a)| {
             if i == 1 && a == "about" {
@@ -207,46 +155,8 @@ fn real_main() -> Result<(), Error> {
 
     setup_logger(args.log_level)?;
 
-    let manifest_path = args
-        .manifest_path
-        .clone()
-        .or_else(|| std::env::current_dir().map(|cd| cd.join("Cargo.toml")).ok())
-        .context("unable to determine manifest path")?;
-
-    if !manifest_path.exists() {
-        bail!(
-            "cargo manifest path '{}' does not exist",
-            manifest_path.display()
-        );
-    }
-
-    let cfg = load_config(&manifest_path)?;
-
-    let (all_crates, store) = rayon::join(
-        || {
-            log::info!("gathering crates for {}", manifest_path.display());
-            cargo_about::get_all_crates(
-                manifest_path,
-                args.no_default_features,
-                args.all_features,
-                args.features.clone(),
-                args.workspace,
-                &cfg,
-            )
-        },
-        || {
-            log::info!("loading license store");
-            cargo_about::licenses::LicenseStore::from_cache()
-        },
-    );
-
-    let all_crates = all_crates?;
-    let store = store?;
-
-    log::info!("gathered {} crates", all_crates.len());
-
     match args.cmd {
-        Command::Generate(gen) => generate::cmd(gen, cfg, all_crates, store),
+        Command::Generate(gen) => generate::cmd(gen),
         Command::Init(init) => init::cmd(init),
     }
 }


### PR DESCRIPTION
Also adds a `--config` argument to allow specifying the about.toml to use instead of the default manifest relative one.

Resolves: #163 