### PR TITLE
Add ignoring of private workspace crates

### DIFF
--- a/docs/src/cli/generate/config.md
+++ b/docs/src/cli/generate/config.md
@@ -59,6 +59,48 @@ workarounds = [
 ]
 ```
 
+## The `private` field (optional)
+
+It's often not useful or wanted to check for licenses in your own private workspace crates. So the private field allows you to do so.
+
+### The `ignore` field
+
+If `true`, workspace members will not have their license expression checked, _if_ they are not published.
+
+```ini
+# Cargo.toml
+[package]
+name = "sekret"
+license = "¯\_(ツ)_/¯"
+publish = false # "private"!
+```
+
+```ini
+# about.toml
+[licenses]
+# The sekret package would be ignored now
+private = { ignore = true }
+```
+
+### The `registries` field
+
+A list of private registries you may publish your workspace crates to. If a workspace member **only** publishes to private registries, it will also be ignored if `private.ignore = true`
+
+```ini
+# Cargo.toml
+[package]
+name = "sekret"
+license = "¯\_(ツ)_/¯"
+publish = ["sauce"]
+```
+
+```ini
+# about.toml
+[licenses]
+# Still ignored!
+private = { ignore = true, registries = ["sauce"] }
+```
+
 ## Crate configuration
 
 Along with the global options, crates can be individually configured as well, using the name of the crate as the key.

--- a/src/licenses/config.rs
+++ b/src/licenses/config.rs
@@ -173,6 +173,21 @@ pub struct KrateConfig {
     pub clarify: Option<Clarification>,
 }
 
+/// Configures how private crates are handled and detected
+#[derive(Deserialize, Default, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct Private {
+    /// If enabled, ignores workspace crates that aren't published, or are
+    /// only published to private registries
+    #[serde(default)]
+    pub ignore: bool,
+    /// One or more private registries that you might publish crates to, if
+    /// a crate is only published to private registries, and `ignore` is true,
+    /// the crate will not have its license checked
+    #[serde(default)]
+    pub registries: Vec<String>,
+}
+
 #[derive(Deserialize, Debug, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
@@ -180,6 +195,9 @@ pub struct Config {
     /// targets
     #[serde(default)]
     pub targets: Vec<String>,
+    /// Configures how private crates are handled and detected
+    #[serde(default)]
+    pub private: Private,
     /// Disallows the use of clearlydefined.io to retrieve harvested license
     /// information and relies purely on local file scanning and clarifications
     #[serde(default)]


### PR DESCRIPTION
Just as with cargo-deny, it's often the case you don't want to have to apply license expressions to private crates https://github.com/EmbarkStudios/cargo-about/issues/171#issuecomment-954826149 just to "successfully" run `generate`, so this just allows you to ignore private crates.

Resolves: #171 