### PR TITLE
Fix ignored private packages being assigned incorrect license

### DIFF
--- a/src/cargo-about/generate.rs
+++ b/src/cargo-about/generate.rs
@@ -256,7 +256,7 @@ struct Input<'a> {
 
 fn generate(
     nfos: &[licenses::KrateLicense<'_>],
-    resolved: &[licenses::Resolved],
+    resolved: &[Option<licenses::Resolved>],
     files: &licenses::resolution::Files,
     stream: term::termcolor::StandardStream,
     hbs: &Handlebars<'_>,
@@ -270,7 +270,11 @@ fn generate(
 
     let licenses = {
         let mut licenses = BTreeMap::new();
-        for (krate_license, resolved) in nfos.iter().zip(resolved.iter()) {
+        for (krate_license, resolved) in nfos
+            .iter()
+            .zip(resolved.iter())
+            .filter_map(|(kl, res)| res.as_ref().map(|res| (kl, res)))
+        {
             if !resolved.diagnostics.is_empty() {
                 let mut streaml = stream.lock();
 

--- a/src/licenses/resolution.rs
+++ b/src/licenses/resolution.rs
@@ -101,7 +101,7 @@ pub fn resolve(
     licenses: &[KrateLicense<'_>],
     accepted: &[Licensee],
     krate_cfg: &std::collections::BTreeMap<String, config::KrateConfig>,
-) -> (Files, Vec<Resolved>) {
+) -> (Files, Vec<Option<Resolved>>) {
     let mut files = codespan::Files::new();
 
     let resolved = licenses
@@ -127,7 +127,7 @@ pub fn resolve(
             let expr = match &kl.lic_info {
                 LicenseInfo::Expr(expr) => std::borrow::Cow::Borrowed(expr),
                 LicenseInfo::Ignore => {
-                    return resolved;
+                    return None;
                 }
                 LicenseInfo::Unknown => {
                     // Find all of the unique license expressions that were discovered
@@ -136,7 +136,7 @@ pub fn resolve(
 
                     if kl.license_files.is_empty() {
                         log::warn!("unable to synthesize license expression for '{}': no `license` specified, and no license files were found", kl.krate);
-                        return resolved;
+                        return Some(resolved);
                     }
 
                     for file in &kl.license_files {
@@ -178,7 +178,7 @@ pub fn resolve(
                                     .with_message(reason.to_string())]),
                             );
 
-                            return resolved;
+                            return Some(resolved);
                         }
                     }
                 }
@@ -255,7 +255,7 @@ pub fn resolve(
                         ),
                 );
 
-                return resolved;
+                return Some(resolved);
             }
 
             // Attempt to  find the minimal set of licenses needed to satisfy the
@@ -269,7 +269,7 @@ pub fn resolve(
                 }
             }
 
-            resolved
+            Some(resolved)
         })
         .collect();
 

--- a/src/licenses/resolution.rs
+++ b/src/licenses/resolution.rs
@@ -56,6 +56,7 @@ impl<'acc> fmt::Display for Accepted<'acc> {
     }
 }
 
+#[derive(Debug)]
 pub struct Resolved {
     /// The minimum license requirements that are required
     pub licenses: Vec<LicenseReq>,
@@ -105,7 +106,7 @@ pub fn resolve(
 
     let resolved = licenses
         .iter()
-        .filter_map(|kl| {
+        .map(|kl| {
             let mut resolved = Resolved {
                 licenses: Vec::new(),
                 diagnostics: Vec::new(),
@@ -126,7 +127,7 @@ pub fn resolve(
             let expr = match &kl.lic_info {
                 LicenseInfo::Expr(expr) => std::borrow::Cow::Borrowed(expr),
                 LicenseInfo::Ignore => {
-                    return None;
+                    return resolved;
                 }
                 LicenseInfo::Unknown => {
                     // Find all of the unique license expressions that were discovered
@@ -135,7 +136,7 @@ pub fn resolve(
 
                     if kl.license_files.is_empty() {
                         log::warn!("unable to synthesize license expression for '{}': no `license` specified, and no license files were found", kl.krate);
-                        return Some(resolved);
+                        return resolved;
                     }
 
                     for file in &kl.license_files {
@@ -177,7 +178,7 @@ pub fn resolve(
                                     .with_message(reason.to_string())]),
                             );
 
-                            return Some(resolved);
+                            return resolved;
                         }
                     }
                 }
@@ -254,7 +255,7 @@ pub fn resolve(
                         ),
                 );
 
-                return Some(resolved);
+                return resolved;
             }
 
             // Attempt to  find the minimal set of licenses needed to satisfy the
@@ -268,7 +269,7 @@ pub fn resolve(
                 }
             }
 
-            Some(resolved)
+            resolved
         })
         .collect();
 


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

The `resolve` function returns a `Vec<Resolved>` that must align with the
licenses gathered earlier since they will be zipped together to create a
crate to license mapping.  If any items are filtered the alignment is thrown
off and crates will be assigned the wrong license.

P.S. The links above in the checklist seem to be incorrect and can't be followed.

### Related Issues

closes #183
