### PR TITLE
Ignore private crates even if outside of workspace

### DIFF
--- a/src/licenses.rs
+++ b/src/licenses.rs
@@ -158,19 +158,19 @@ impl Gatherer {
 
         let git_cache = fetch::GitCache::default();
 
-        // If we're ignoring workspace crates that are private, just add them
+        // If we're ignoring crates that are private, just add them
         // to the list so all of the following gathers ignore them
         if cfg.private.ignore {
-            for wm in krates.workspace_members() {
-                if let Some(publish) = &wm.krate.publish {
+            for krate in krates.krates() {
+                if let Some(publish) = &krate.krate.publish {
                     if publish.is_empty()
                         || publish
                             .iter()
                             .all(|reg| cfg.private.registries.contains(reg))
                     {
-                        log::debug!("ignoring private workspace crate '{}'", wm.krate);
+                        log::debug!("ignoring private crate '{}'", krate.krate);
                         licensed_krates.push(KrateLicense {
-                            krate: &wm.krate,
+                            krate: &krate.krate,
                             lic_info: LicenseInfo::Ignore,
                             license_files: Vec::new(),
                         });


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Ignore licenses for any crate that has `publish = false` set, even if they are outside of the workspace.  This is helpful when when the project depends on another private repository that is not published.

### Related Issues

closes #185
