### PR TITLE
Allow to ignore non-workspace dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Added
+- [PR#188](https://github.com/EmbarkStudios/cargo-about/pull/188) added the ability to ignore transitive dependencies via the `ignore-transitive-dependencies` config flag. Thanks [@haraldreingruber](https://github.com/haraldreingruber)!
+- [PR#188](https://github.com/EmbarkStudios/cargo-about/pull/188) added a `crates` property to the handlebars context, see the [about_list_by_crate_example](about_list_by_crate_example.hbs) for how it can be used. Thanks [@haraldreingruber](https://github.com/haraldreingruber)!
+
 ### Changed
 - [PR#189](https://github.com/EmbarkStudios/cargo-about/pull/189) updated dependencies, notably `regex` to fix an [advisory](https://rustsec.org/advisories/RUSTSEC-2022-0013).
 

--- a/about.hbs
+++ b/about.hbs
@@ -56,7 +56,7 @@
         </table>
 
         <h2>License texts:</h2>
-        {{#each licenses}}
+        {{#each overview}}
             <h3 id="{{id}}">{{name}}</h3>
             <pre class="license-text">{{text}}</pre>
         {{/each}}

--- a/about.hbs
+++ b/about.hbs
@@ -1,6 +1,8 @@
+<!DOCTYPE html>
 <html>
 
 <head>
+    <meta charset="utf-8">
     <style>
         @media (prefers-color-scheme: dark) {
             body {
@@ -38,29 +40,33 @@
 <body>
     <main class="container">
         <div class="intro">
-            <h1>Third-Party Licenses</h1>
+            <h1>Third Party Licenses</h1>
             <p>This page lists the licenses of the projects used in cargo-about.</p>
         </div>
+    
+        <h2>Overview of licenses:</h2>
+        <ul class="licenses-overview">
+            {{#each overview}}
+            <li><a href="#{{id}}">{{name}}</a> ({{count}})</li>
+            {{/each}}
+        </ul>
 
-        <h2>Third-party components:</h2>
-        <table>
-        {{#each crates}}
-            <tr>
-                <td><a href="{{#if package.repository}} {{package.repository}} {{else}} https://crates.io/crates/{{package.name}} {{/if}}">
-                    {{package.name}}
-                </a></td>
-                <td>{{package.version}}</td>
-                <td>{{license}}</td>
-            </tr>
-        {{/each}}
-        </table>
-
-        <h2>License texts:</h2>
-        {{#each overview}}
-            <h3 id="{{id}}">{{name}}</h3>
-            <pre class="license-text">{{text}}</pre>
-        {{/each}}
-</main>
+        <h2>All license text:</h2>
+        <ul class="licenses-list">
+            {{#each licenses}}
+            <li class="license">
+                <h3 id="{{id}}">{{name}}</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    {{#each used_by}}
+                    <li><a href="{{#if crate.repository}} {{crate.repository}} {{else}} https://crates.io/crates/{{crate.name}} {{/if}}">{{crate.name}} {{crate.version}}</a></li>
+                    {{/each}}
+                </ul>
+                <pre class="license-text">{{text}}</pre>
+            </li>
+            {{/each}}
+        </ul>
+    </main>
 </body>
 
 </html>

--- a/about.hbs
+++ b/about.hbs
@@ -46,10 +46,10 @@
         <table>
         {{#each crates}}
             <tr>
-                <td><a href="{{#if repository}} {{repository}} {{else}} https://crates.io/crates/{{name}} {{/if}}">
-                    {{name}}
+                <td><a href="{{#if package.repository}} {{package.repository}} {{else}} https://crates.io/crates/{{package.name}} {{/if}}">
+                    {{package.name}}
                 </a></td>
-                <td>{{version}}</td>
+                <td>{{package.version}}</td>
                 <td>{{license}}</td>
             </tr>
         {{/each}}

--- a/about.hbs
+++ b/about.hbs
@@ -1,8 +1,6 @@
-<!DOCTYPE html>
 <html>
 
 <head>
-    <meta charset="utf-8">
     <style>
         @media (prefers-color-scheme: dark) {
             body {
@@ -40,33 +38,29 @@
 <body>
     <main class="container">
         <div class="intro">
-            <h1>Third Party Licenses</h1>
+            <h1>Third-Party Licenses</h1>
             <p>This page lists the licenses of the projects used in cargo-about.</p>
         </div>
-    
-        <h2>Overview of licenses:</h2>
-        <ul class="licenses-overview">
-            {{#each overview}}
-            <li><a href="#{{id}}">{{name}}</a> ({{count}})</li>
-            {{/each}}
-        </ul>
 
-        <h2>All license text:</h2>
-        <ul class="licenses-list">
-            {{#each licenses}}
-            <li class="license">
-                <h3 id="{{id}}">{{name}}</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    {{#each used_by}}
-                    <li><a href="{{#if crate.repository}} {{crate.repository}} {{else}} https://crates.io/crates/{{crate.name}} {{/if}}">{{crate.name}} {{crate.version}}</a></li>
-                    {{/each}}
-                </ul>
-                <pre class="license-text">{{text}}</pre>
-            </li>
-            {{/each}}
-        </ul>
-    </main>
+        <h2>Third-party components:</h2>
+        <table>
+        {{#each crates}}
+            <tr>
+                <td><a href="{{#if repository}} {{repository}} {{else}} https://crates.io/crates/{{name}} {{/if}}">
+                    {{name}}
+                </a></td>
+                <td>{{version}}</td>
+                <td>{{license}}</td>
+            </tr>
+        {{/each}}
+        </table>
+
+        <h2>License texts:</h2>
+        {{#each licenses}}
+            <h3 id="{{id}}">{{name}}</h3>
+            <pre class="license-text">{{text}}</pre>
+        {{/each}}
+</main>
 </body>
 
 </html>

--- a/about.toml
+++ b/about.toml
@@ -7,6 +7,7 @@ targets = [
 ]
 ignore-build-dependencies = false
 ignore-dev-dependencies = false
+ignore-transitive-dependencies = true
 workarounds = ["ring", "chrono", "rustls"]
 
 [codespan.clarify]

--- a/about.toml
+++ b/about.toml
@@ -7,7 +7,7 @@ targets = [
 ]
 ignore-build-dependencies = false
 ignore-dev-dependencies = false
-ignore-non-workspace-dependencies = true
+ignore-non-workspace-dependencies = false
 workarounds = ["ring", "chrono", "rustls"]
 
 [codespan.clarify]

--- a/about.toml
+++ b/about.toml
@@ -7,7 +7,7 @@ targets = [
 ]
 ignore-build-dependencies = false
 ignore-dev-dependencies = false
-ignore-non-workspace-dependencies = false
+ignore-transitive-dependencies = false
 workarounds = ["ring", "chrono", "rustls"]
 
 [codespan.clarify]

--- a/about.toml
+++ b/about.toml
@@ -7,7 +7,7 @@ targets = [
 ]
 ignore-build-dependencies = false
 ignore-dev-dependencies = false
-ignore-transitive-dependencies = true
+ignore-non-workspace-dependencies = true
 workarounds = ["ring", "chrono", "rustls"]
 
 [codespan.clarify]

--- a/about_list_by_crate_example.hbs
+++ b/about_list_by_crate_example.hbs
@@ -1,0 +1,66 @@
+<html>
+
+<head>
+    <style>
+        @media (prefers-color-scheme: dark) {
+            body {
+                background: #333;
+                color: white;
+            }
+            a {
+                color: skyblue;
+            }
+        }
+        .container {
+            font-family: sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+        }
+        .intro {
+            text-align: center;
+        }
+        .licenses-list {
+            list-style-type: none;
+            margin: 0;
+            padding: 0;
+        }
+        .license-used-by {
+            margin-top: -10px;
+        }
+        .license-text {
+            max-height: 200px;
+            overflow-y: scroll;
+            white-space: pre-wrap;
+        }
+    </style>
+</head>
+
+<body>
+    <main class="container">
+        <div class="intro">
+            <h1>Third-Party Licenses</h1>
+            <p>This page lists the licenses of the projects used in cargo-about.</p>
+        </div>
+
+        <h2>Third-party components:</h2>
+        <table>
+        {{#each crates}}
+            <tr>
+                <td><a href="{{#if package.repository}} {{package.repository}} {{else}} https://crates.io/crates/{{package.name}} {{/if}}">
+                    {{package.name}}
+                </a></td>
+                <td>{{package.version}}</td>
+                <td>{{license}}</td>
+            </tr>
+        {{/each}}
+        </table>
+
+        <h2>License texts:</h2>
+        {{#each overview}}
+            <h3 id="{{id}}">{{name}}</h3>
+            <pre class="license-text">{{text}}</pre>
+        {{/each}}
+</main>
+</body>
+
+</html>

--- a/docs/src/cli/generate/config.md
+++ b/docs/src/cli/generate/config.md
@@ -42,6 +42,14 @@ If true, all crates that are only used as dev dependencies will be ignored.
 ignore-dev-dependencies = true
 ```
 
+## The `ignore-transitive-dependencies` field (optional)
+
+If true, only direct dependencies of crates in the workspace will be included in the graph, transitive dependencies (dependencies of dependencies) will be ignored.
+
+```ini
+ignore-transitive-dependencies = true
+```
+
 ## The `no-clearly-defined` field (optional)
 
 If true, will not attempt to lookup licensing information for any crate from <https://clearlydefined.io>, only user clarifications, workarounds, and local file scanning will be used to determine licensing information.

--- a/src/cargo-about/generate.rs
+++ b/src/cargo-about/generate.rs
@@ -248,6 +248,7 @@ struct LicenseSet {
     name: String,
     id: String,
     indices: Vec<usize>,
+    text: String,
 }
 
 #[derive(Serialize)]
@@ -400,6 +401,7 @@ fn generate(
                     name: lic.name.clone(),
                     id: lic.id.clone(),
                     indices: Vec::with_capacity(10),
+                    text: lic.text.clone(),
                 };
 
                 ls.indices.push(ndx);

--- a/src/cargo-about/generate.rs
+++ b/src/cargo-about/generate.rs
@@ -2,9 +2,11 @@ use anyhow::{self, bail, Context as _};
 use cargo_about::licenses;
 use codespan_reporting::term;
 use handlebars::Handlebars;
+use krates::cm::{Package, PackageId};
 use krates::{Utf8Path as Path, Utf8PathBuf as PathBuf};
 use serde::Serialize;
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 
 #[derive(clap::Parser, Debug)]
 pub struct Args {
@@ -252,6 +254,7 @@ struct LicenseSet {
 struct Input<'a> {
     overview: Vec<LicenseSet>,
     licenses: Vec<License<'a>>,
+    crates: Vec<&'a krates::cm::Package>,
 }
 
 fn generate(
@@ -409,7 +412,21 @@ fn generate(
     // Show the most used licenses first
     overview.sort_by(|a, b| b.count.cmp(&a.count));
 
-    let nput = Input { overview, licenses };
+    let mut crates_map: HashMap<&PackageId, &Package> = HashMap::with_capacity(256);
+    licenses.iter().for_each(|license| {
+        license.used_by.iter().for_each(|used_by| {
+            crates_map.insert(&used_by.krate.id, used_by.krate);
+        })
+    });
+
+    let mut crates: Vec<&Package> = crates_map.values().cloned().collect();
+    crates.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let nput = Input {
+        overview,
+        licenses,
+        crates,
+    };
 
     Ok(hbs.render(template_name, &nput)?)
 }

--- a/src/cargo-about/generate.rs
+++ b/src/cargo-about/generate.rs
@@ -1,5 +1,6 @@
 use anyhow::{self, bail, Context as _};
 use cargo_about::licenses;
+use cargo_about::licenses::LicenseInfo;
 use codespan_reporting::term;
 use handlebars::Handlebars;
 use krates::cm::Package;
@@ -415,6 +416,7 @@ fn generate(
 
     let crates = nfos
         .iter()
+        .filter(|nfo| !matches!(nfo.lic_info, LicenseInfo::Ignore))
         .map(|nfo| PackageLicense {
             package: &nfo.krate.0,
             license: nfo.lic_info.to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ use std::{cmp, fmt};
 
 pub mod licenses;
 
-pub struct Krate(cm::Package);
+pub struct Krate(pub cm::Package);
 
 impl Krate {
     fn get_license_expression(&self) -> licenses::LicenseInfo {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,7 +213,7 @@ pub fn get_all_crates(
         builder.ignore_kind(krates::DepKind::Dev, krates::Scope::All);
     }
 
-    if cfg.ignore_transitive_dependencies {
+    if cfg.ignore_non_workspace_dependencies {
         builder.ignore_kind(krates::DepKind::Normal, krates::Scope::NonWorkspace);
         builder.ignore_kind(krates::DepKind::Dev, krates::Scope::NonWorkspace);
         builder.ignore_kind(krates::DepKind::Build, krates::Scope::NonWorkspace);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,6 +213,12 @@ pub fn get_all_crates(
         builder.ignore_kind(krates::DepKind::Dev, krates::Scope::All);
     }
 
+    if cfg.ignore_transitive_dependencies {
+        builder.ignore_kind(krates::DepKind::Normal, krates::Scope::NonWorkspace);
+        builder.ignore_kind(krates::DepKind::Dev, krates::Scope::NonWorkspace);
+        builder.ignore_kind(krates::DepKind::Build, krates::Scope::NonWorkspace);
+    }
+
     builder.include_targets(cfg.targets.iter().map(|triple| (triple.as_str(), vec![])));
 
     let graph = builder.build(mdc, |filtered: cm::Package| match filtered.source {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,7 +213,7 @@ pub fn get_all_crates(
         builder.ignore_kind(krates::DepKind::Dev, krates::Scope::All);
     }
 
-    if cfg.ignore_non_workspace_dependencies {
+    if cfg.ignore_transitive_dependencies {
         builder.ignore_kind(krates::DepKind::Normal, krates::Scope::NonWorkspace);
         builder.ignore_kind(krates::DepKind::Dev, krates::Scope::NonWorkspace);
         builder.ignore_kind(krates::DepKind::Build, krates::Scope::NonWorkspace);

--- a/src/licenses.rs
+++ b/src/licenses.rs
@@ -9,7 +9,7 @@ use anyhow::Context as _;
 use krates::Utf8PathBuf as PathBuf;
 use rayon::prelude::*;
 pub use resolution::Resolved;
-use std::{cmp, sync::Arc};
+use std::{cmp, fmt, sync::Arc};
 
 const LICENSE_CACHE: &[u8] = include_bytes!("../spdx_cache.bin.zstd");
 
@@ -26,6 +26,16 @@ pub enum LicenseInfo {
     Expr(spdx::Expression),
     Unknown,
     Ignore,
+}
+
+impl fmt::Display for LicenseInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LicenseInfo::Expr(expr) => write!(f, "{}", expr),
+            LicenseInfo::Unknown => write!(f, "Unknown"),
+            LicenseInfo::Ignore => write!(f, "Ignore"),
+        }
+    }
 }
 
 /// The contents of a file with license info in it

--- a/src/licenses/config.rs
+++ b/src/licenses/config.rs
@@ -208,9 +208,10 @@ pub struct Config {
     /// Ignores any dev dependencies in the graph
     #[serde(default)]
     pub ignore_dev_dependencies: bool,
-    /// Ignores any non-workspace dependencies in the graph, so it basically only considers direct dependencies
+    /// Ignores any transitive dependencies in the graph, ie, only direct
+    /// dependencies of crates in the workspace will be included
     #[serde(default)]
-    pub ignore_non_workspace_dependencies: bool,
+    pub ignore_transitive_dependencies: bool,
     /// The list of licenses we will use for all crates, in priority order
     #[serde(deserialize_with = "deserialize_licensee")]
     pub accepted: Vec<spdx::Licensee>,

--- a/src/licenses/config.rs
+++ b/src/licenses/config.rs
@@ -208,9 +208,9 @@ pub struct Config {
     /// Ignores any dev dependencies in the graph
     #[serde(default)]
     pub ignore_dev_dependencies: bool,
-    /// Ignores any transitive dependencies in the graph, so it basically only considers direct dependencies
+    /// Ignores any non-workspace dependencies in the graph, so it basically only considers direct dependencies
     #[serde(default)]
-    pub ignore_transitive_dependencies: bool,
+    pub ignore_non_workspace_dependencies: bool,
     /// The list of licenses we will use for all crates, in priority order
     #[serde(deserialize_with = "deserialize_licensee")]
     pub accepted: Vec<spdx::Licensee>,

--- a/src/licenses/config.rs
+++ b/src/licenses/config.rs
@@ -208,6 +208,9 @@ pub struct Config {
     /// Ignores any dev dependencies in the graph
     #[serde(default)]
     pub ignore_dev_dependencies: bool,
+    /// Ignores any transitive dependencies in the graph, so it basically only considers direct dependencies
+    #[serde(default)]
+    pub ignore_transitive_dependencies: bool,
     /// The list of licenses we will use for all crates, in priority order
     #[serde(deserialize_with = "deserialize_licensee")]
     pub accepted: Vec<spdx::Licensee>,


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

* A config flag is added to ignore non-workspace dependencies, which is used for calling the `builder.ignore_kind()` method. 
* The list of crates is added to the input of the `handlebars` template so that the list of third-party licenses can be displayed also by crate.
* The license text is added to the license summary/overview struct, so that the text for each kind of license can be displayed.
* The handlebars template used for the above mentioned use-cases has been added as an example in [./about_list_by_crate_example.hbs](./about_list_by_crate_example.hbs). Not sure if this is the best place, but the idea was that it might be useful to have this example somewhere? 

### Related Issues

This PR solves a problem similiar to the description in #144. After discovering that crates can be ignored by scope, I realized this is a nice way to achieve a similar result. If the intention is to generate a list of third-party crates and licenses, then non-workspace is probably even better compared to transitive dependencies which might include workspace crates (as they are usually not from a third-party).
