### PR TITLE
Accept BSD-3-Clause for encoding_rs crate

### DIFF
--- a/about.toml
+++ b/about.toml
@@ -31,6 +31,9 @@ license = "Apache-2.0 OR MIT"
 path = "LICENSE"
 checksum = "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4"
 
+[encoding_rs]
+accepted = ["BSD-3-Clause"]
+
 [instant]
 accepted = ["BSD-3-Clause"]
 


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Running `cargo about generate -o license.html about.hbs` fails to generate a report for the `cargo-about` repository as it doesn't accept `BSD-3-Clause` for the `encoding_rs` crate. This change adds an exception for the `encoding_rs` crate to accept `BSD-3-Clause`. I thought that might be reasonable since this exception is already being made for the `instant` crate. Let me know if you'd rather add `BSD-3-Clause` to the global accepted field instead of making more exceptions.

Btw, I saw that `encoding_rs` crate only added added this license about 4 months ago in [this commit](https://github.com/hsivonen/encoding_rs/commit/3a4033e67b6b9d1c1e9514bcb5c20ae05bf8391d).

#### Steps taken
```sh
$ cargo install cargo-about
$ git clone https://github.com/EmbarkStudios/cargo-about.git
$ cd cargo-about
$ cargo about generate -o license.html about.hbs
```

#### Error message
```sh
2022-04-10 17:00:31.236111737 +00:00:00 [WARN] clearlydefined detected license in 'COPYING' for crate 'bstr 0.2.17', but it we failed to determine what its license was
2022-04-10 17:00:31.628013189 +00:00:00 [WARN] crate 'encoding_rs 0.8.30' doesn't have a license field
2022-04-10 17:00:33.752224131 +00:00:00 [WARN] clearlydefined detected license in 'LICENSE' for crate 'typenum 1.15.0', but it we failed to determine what its license was
2022-04-10 17:00:33.967640188 +00:00:00 [WARN] crate 'webpki 0.22.0' doesn't have a license field
error: failed to satisfy license requirements
    /home/arch/.cargo/registry/src/github.com-1ecc6299db9ec823/encoding_rs-0.8.30/Cargo.toml:25:30
   
25  license = "(Apache-2.0) AND (BSD-3-Clause) AND (MIT) AND (MIT AND MIT OR Apache-2.0) AND (MIT OR Apache-2.0)"
                                 ------------

2022-04-10 17:00:34.916539795 +00:00:00 [ERROR] encountered 1 errors resolving licenses, unable to generate output
```

### Related Issues

None.
