### PR TITLE
Add security policy with GitHub private reporting & Bug Bounty

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security policy
+
+Protecting your privacy and our products is paramount to establishing trust with our players and users. Therefore, we consistently tweak and enhance our ways of working with security, and aim to be as transparent as possible about this effort.
+
+We truly appreciate efforts to discover and disclose security issues responsibly.
+
+If you’re a security researcher looking to submit a report about a security vulnerability, this repository has GitHub's [Private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) enabled where you directly can submit reports to us privately and securely, as well as optionally create a private fork to help fix the issue.
+
+This is repository is also part of our [Security Bug Bounty Program](https://www.intigriti.com/programs) hosted by Intigriti. Please note that in order to report via Intigriti, you need to be a registered user.
+
+If you’d like to report a security issue found in any of our other products or have security concerns regarding Embark Studios, please reach out to security@embark-studios.com.


### PR DESCRIPTION
This is an updated version of our [standard security policy](https://github.com/EmbarkStudios/.github/blob/master/SECURITY.md) to be adapted for our repositories that use GitHub's new [Private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) as well as our Security Bug Bounty Program, which we now use here for cargo-deny 🎉

Just like we did for cargo-deny: https://github.com/EmbarkStudios/cargo-deny/pull/485
