### PR TITLE
Add option to fail if a crate's license cannot be reasonably discovered

### DIFF
--- a/src/cargo-about/generate.rs
+++ b/src/cargo-about/generate.rs
@@ -42,6 +42,9 @@ pub struct Args {
     /// Scan licenses for the entire workspace, not just the active package
     #[clap(long)]
     workspace: bool,
+    /// Generate an error code when failing to read, synthesize, or clarify a license expression for a crate
+    #[clap(long)]
+    fail_on_missing_license: bool,
     /// The template(s) or template directory to use. Must either be a `.hbs`
     /// file, or have at least one `.hbs` file in it if it is a directory
     templates: PathBuf,
@@ -188,7 +191,12 @@ pub fn cmd(args: Args, color: crate::Color) -> anyhow::Result<()> {
         .with_confidence_threshold(args.threshold)
         .gather(&krates, &cfg);
 
-    let (files, resolved) = licenses::resolution::resolve(&summary, &cfg.accepted, &cfg.crates);
+    let (files, resolved) = licenses::resolution::resolve(
+        &summary,
+        &cfg.accepted,
+        &cfg.crates,
+        args.fail_on_missing_license,
+    );
 
     use term::termcolor::ColorChoice;
 

--- a/src/licenses/resolution.rs
+++ b/src/licenses/resolution.rs
@@ -100,6 +100,7 @@ pub fn resolve(
     licenses: &[KrateLicense<'_>],
     accepted: &[Licensee],
     krate_cfg: &std::collections::BTreeMap<String, config::KrateConfig>,
+    fail_on_missing: bool,
 ) -> (Files, Vec<Option<Resolved>>) {
     let mut files = codespan::Files::new();
 
@@ -133,7 +134,14 @@ pub fn resolve(
                     let mut unique_exprs = Vec::new();
 
                     if kl.license_files.is_empty() {
-                        log::warn!("unable to synthesize license expression for '{}': no `license` specified, and no license files were found", kl.krate);
+                        let msg = format!("unable to synthesize license expression for '{}': no `license` specified, and no license files were found", kl.krate);
+
+                        if fail_on_missing {
+                            resolved.diagnostics.push(Diagnostic::new(Severity::Error).with_message(msg));
+                        } else {
+                            log::warn!("{}", msg);
+                        }
+
                         return Some(resolved);
                     }
 


### PR DESCRIPTION
Hi y'all, thanks for creating this awesome project :)

As part of integrating this into our CI builds we wanted an option to fail CI if a crate's license could not be determined. I initially set out to implement [#203](https://github.com/EmbarkStudios/cargo-about/issues/203) but quickly discovered that there are a lot of warnings generated for problems that get fixed in a later pass (e.g. failing to read a license identifier but successfully synthesizing one). I tried to put my check as late in the process as possible so that this flag only generates errors in truly unrecoverable situations. As such I think this PR captures the spirit of #203, if not the wording. 

For testing I temporarily added this line as a dependency to cargo about: 

```toml
procinfo = { git = "https://github.com/zed-industries/wezterm", rev = "5cd757e5f2eb039ed0c6bb6512223e69d5efc64d", default-features = false }
```

For whatever reason, this dependency's license cannot be detected by `cargo about`, probably because we're depending on a module in this non-library project rather than going through crates.io. Regardless, running `cargo run generate --fail_on_missing_license about.hbs` should now generate an error like so:

```
2023-01-23 19:58:56.211281 +00:00:00 [WARN] crate 'procinfo 0.1.0' doesn't have a license field
error: unable to synthesize license expression for 'procinfo 0.1.0': no `license` specified, and no license files were found

2023-01-23 19:59:01.615755 +00:00:00 [ERROR] encountered 1 errors resolving licenses, unable to generate output
```

Adding the following field to `about.toml` should fix said error:

```toml
[procinfo.clarify]
license = "MIT"
[[procinfo.clarify.git]]
path = 'LICENSE.md'
checksum = '37db33bbbd7348969eda397b89a16f252d56c1ca7481b6ccaf56ccdcbab5dcca'
```

Let me know if there's anything I can fix or reformat :)

### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Adds a `fail_on_missing_license` flag to the CLI.

### Related Issues

#203 
