### PR TITLE
Add filtering of `NOASSERTION`

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -92,6 +92,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-unknown-linux-musl
+      - run: sudo apt install -y musl-tools
       - uses: Swatinem/rust-cache@v2
       - run: cargo run --release --target x86_64-unknown-linux-musl -- generate --fail about.hbs
 

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -93,7 +93,7 @@ jobs:
         with:
           targets: x86_64-unknown-linux-musl
       - uses: Swatinem/rust-cache@v2
-      - run: cargo run --release -- generate --fail about.hbs
+      - run: cargo run --release --target x86_64-unknown-linux-musl -- generate --fail about.hbs
 
   # Build `mdBook` documentation and upload it as a temporary build artifact
   doc-book:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -84,6 +84,17 @@ jobs:
       - uses: actions/checkout@v3
       - uses: EmbarkStudios/cargo-deny-action@v1
 
+  check-self:
+    name: cargo-about
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-musl
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo run --release -- generate --fail about.hbs
+
   # Build `mdBook` documentation and upload it as a temporary build artifact
   doc-book:
     name: Build the book

--- a/about.toml
+++ b/about.toml
@@ -8,6 +8,7 @@ targets = [
 ignore-build-dependencies = false
 ignore-dev-dependencies = false
 ignore-transitive-dependencies = false
+filter-noassertion = true
 workarounds = ["ring", "chrono", "rustls"]
 
 [codespan.clarify]
@@ -39,6 +40,9 @@ accepted = ["BSD-3-Clause"]
 
 [ring]
 accepted = ["ISC", "OpenSSL"]
+
+[unicode-ident]
+accepted = ["Unicode-DFS-2016"]
 
 [untrusted]
 accepted = ["ISC"]

--- a/docs/src/cli/generate/config.md
+++ b/docs/src/cli/generate/config.md
@@ -54,6 +54,12 @@ ignore-transitive-dependencies = true
 
 If true, will not attempt to lookup licensing information for any crate from <https://clearlydefined.io>, only user clarifications, workarounds, and local file scanning will be used to determine licensing information.
 
+## The `filter-noassertion` field (optional)
+
+If using <https://clearlydefined.io> to gather license information, that service will conservatively add [`NOASSERTION`](https://docs.clearlydefined.io/curation-guidelines) to the expression for files that contain license like data, but an SPDX license ID could not be confidently ascribed to it. This can result in the license expression for the crate to contain 1 or more `NOASSERTION` identifiers, which would require the user to accept that (not really valid) ID to pass the license check. By setting this field to `true`, files that have a `NOASSERTION` id will instead be scanned locally, which will generally either figure out the license, or else skip that file.
+
+For a real world example of what this looks like, [`webpki:0.22.0`](https://crates.io/crates/webpki/0.22.0)'s [LICENSE](https://clearlydefined.io/file/5b698ca13897be3afdb7174256fa1574f8c6892b8bea1a66dd6469d3fe27885a) file is an ISC license, however it has a preamble that is not part of the ISC license that trips up clearly defined's inspection, causing it to be attributed with `ISC AND NOASSERTION`. Locally scanning the file will be more tolerant and just attribute it with `ISC`.
+
 ## The `workarounds` field (optional)
 
 Unfortunately, not all crates properly package their licenses, or if they do, sometimes in a non-machine readable format, or in a few cases, are slightly wrong. These can be clarified manually via configuration, but some crates that are widely used in the Rust ecosystem have these issues, and rather than require that every cargo-about user who happens to have a dependency on one or more of these crates specify the same config to get it working, cargo-about instead includes a few built-in clarifications that can be opted into with a single config entry rather than redoing work.

--- a/src/licenses.rs
+++ b/src/licenses.rs
@@ -353,7 +353,7 @@ impl Gatherer {
                                 // with a license or SPDX identifier, but like askalono it won't
                                 // detect all licenses if there are multiple in a single file
                                 match (cd_file.license, license_text) {
-                                    (Some(lic), license_text) => {
+                                    (Some(lic), license_text) if !cfg.filter_noassertion || !lic.contains("NOASSERTION") => {
                                         let license_expr = match spdx::Expression::parse_mode(&lic, spdx::ParseMode::LAX) {
                                             Ok(expr) => expr,
                                             Err(err) => {

--- a/src/licenses/config.rs
+++ b/src/licenses/config.rs
@@ -212,6 +212,13 @@ pub struct Config {
     /// dependencies of crates in the workspace will be included
     #[serde(default)]
     pub ignore_transitive_dependencies: bool,
+    /// When using clearlydefined.io to gather harvested license information, it
+    /// will conservatively add `NOASSERTION` to any file that contains a license
+    /// that either cannot be identified, or diverges enough from the canonical
+    /// license text. This is not really useful in most cases, so this option
+    /// will remove the any instance of `NOASSERTION` to reduce noise.
+    #[serde(default)]
+    pub filter_noassertion: bool,
     /// The list of licenses we will use for all crates, in priority order
     #[serde(deserialize_with = "deserialize_licensee")]
     pub accepted: Vec<spdx::Licensee>,


### PR DESCRIPTION
If using <https://clearlydefined.io> to gather license information, that service will conservatively add [`NOASSERTION`](https://docs.clearlydefined.io/curation-guidelines) to the expression for files that contain license like data, but an SPDX license ID could not be confidently ascribed to it. This can result in the license expression for the crate to contain 1 or more `NOASSERTION` identifiers, which would require the user to accept that (not really valid) ID to pass the license check. By setting this field to `true`, files that have a `NOASSERTION` id will instead be scanned locally, which will generally either figure out the license, or else skip that file.

For a real world example of what this looks like, [`webpki:0.22.0`](https://crates.io/crates/webpki/0.22.0)'s [LICENSE](https://clearlydefined.io/file/5b698ca13897be3afdb7174256fa1574f8c6892b8bea1a66dd6469d3fe27885a) file is an ISC license, however it has a preamble that is not part of the ISC license that trips up clearly defined's inspection, causing it to be attributed with `ISC AND NOASSERTION`. Locally scanning the file will be more tolerant and just attribute it with `ISC`.

This also makes it so that we actually run cargo about on itself in CI to check that our config is actually good :stuck_out_tongue: 