### PR TITLE
deps: Update proc-macro2 in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1209,9 +1209,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Updates the `proc-macro2` dependency in the `Cargo.lock` file by running `cargo update -p proc-macro2`.

In versions of Rust nightly >= 2023-06-28 a compiler feature was removed that `proc_macro2` uses. This issue has since been fixed in https://github.com/dtolnay/proc-macro2/pull/391.

### Related Issues

https://github.com/rust-lang/rust/issues/113152
