### PR TITLE
Fix ring workaround version check

### DIFF
--- a/src/licenses/workarounds/ring.rs
+++ b/src/licenses/workarounds/ring.rs
@@ -1,5 +1,6 @@
 use super::ClarificationFile;
 use anyhow::Context as _;
+use krates::cm::semver::Version;
 
 pub fn get(krate: &crate::Krate) -> anyhow::Result<Option<super::Clarification>> {
     if krate.name != "ring" {
@@ -8,8 +9,9 @@ pub fn get(krate: &crate::Krate) -> anyhow::Result<Option<super::Clarification>>
 
     // Older versions of ring tend to get yanked so instead of covering all versions
     // we just cover the current stable version
+    let min_version = Version::new(0, 16, 0);
     anyhow::ensure!(
-        krate.version.minor == 16,
+        krate.version >= min_version,
         "version {} is not covered, please file a PR to add it",
         krate.version
     );


### PR DESCRIPTION
With this fix I'm trying to fix a problem with `workaround` for `ring` trait.
Before it showed me this Warning:
`[DEBUG] unable to apply workaround 'ring' to 'ring 0.17.5': version 0.17.5 is not covered, please file a PR to add it`
and at the end I got an error:
```
 error: failed to satisfy license requirements <<< custom part
    ┌─ /Users/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.17.5/Cargo.toml:170:13
    │
170 │ license = "(GPL-1.0-or-later AND OpenSSL AND OpenSSL OR BSD-3-Clause) AND (ISC) AND (ISC AND MIT AND OpenSSL AND OpenSSL AND ISC) AND (ISC AND NOASSERTION) AND (MIT) AND (NOASSERTION) AND (NOASSERTION AND OpenSSL) AND (OpenSSL) AND (OpenSSL AND OpenSSL OR (BSD-3-Clause OR (GPL-1.0-or-later OR GPL-2.0-only))) AND (OpenSSL AND OpenSSL OR (BSD-3-Clause OR GPL-1.0-or-later)) AND (OpenSSL AND OpenSSL OR BSD-3-Clause)"
```