### PR TITLE
Add missing `<title>` element

### DIFF
--- a/about.hbs
+++ b/about.hbs
@@ -35,6 +35,7 @@
             white-space: pre-wrap;
         }
     </style>
+    <title>Third Party Licenses</title>
 </head>
 
 <body>


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

[According to the HTML Standard][1]:

> The title element is a required child in most situations, but when a higher-level protocol provides title information, e.g., in the subject line of an email when HTML is used as an email authoring format, the title element can be omitted.

Before this change, the default about.hbs file didn’t have a &lt;title&gt; element even though a &lt;title&gt; element is required in most situations. This change adds a &lt;title&gt; element in order to help make sure that the HTML generated by cargo-about is valid.

[1]: https://html.spec.whatwg.org/multipage/semantics.html#the-head-element

### Related Issues