### PR TITLE
Fix the HTML syntax in the template

### DIFF
--- a/about.hbs
+++ b/about.hbs
@@ -44,7 +44,7 @@
             <h1>Third Party Licenses</h1>
             <p>This page lists the licenses of the projects used in cargo-about.</p>
         </div>
-    
+
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
             {{#each overview}}
@@ -55,16 +55,16 @@
         <h2>All license text:</h2>
         <ul class="licenses-list">
             {{#each licenses}}
-                <!-- Write out a header for each block of the same license -->
-                {{#if first_of_kind}}
-                    <h3 id="{{id}}">{{name}}</h3>
-                {{/if}}
                 <li class="license">
-                    <h4 id="{{id}}-{{@index}}">{{name}}</h>
+                    {{! Write out a header for each block of the same license }}
+                    {{#if first_of_kind}}
+                        <h3 id="{{id}}">{{name}}</h3>
+                    {{/if}}
+                    <h4 id="{{id}}-{{@index}}">{{name}}</h4>
                     <h5>Used by:</h5>
                     <ul class="license-used-by">
                         {{#each used_by}}
-                        <li><a href="{{#if crate.repository}} {{crate.repository}} {{else}} https://crates.io/crates/{{crate.name}} {{/if}}">{{crate.name}} {{crate.version}}</a></li>
+                        <li><a href="{{#if crate.repository}}{{crate.repository}}{{else}}https://crates.io/crates/{{crate.name}}{{/if}}">{{crate.name}} {{crate.version}}</a></li>
                         {{/each}}
                     </ul>
                     <pre class="license-text">{{text}}</pre>


### PR DESCRIPTION
* close the `<h4>` tag
* move the `<h3>` into `<li>`
* remove spaces in the link

### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Fix HTML syntax bugs in the template.

The generated documents now pass the syntax check at https://validator.w3.org/