### PR TITLE
chore: make links in `pull_request_template.md` absolute path

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 ### Checklist
 
-* [ ] I have read the [Contributor Guide](../CONTRIBUTING.md)
-* [ ] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
+* [ ] I have read the [Contributor Guide](https://github.com/EmbarkStudios/cargo-about/blob/main/CONTRIBUTING.md)
+* [ ] I have read and agree to the [Code of Conduct](https://github.com/EmbarkStudios/cargo-about/blob/main/CODE_OF_CONDUCT.md)
 * [ ] I have added a description of my changes and why I'd like them included in the section below
 
 ### Description of Changes


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes
For now, the links in `pull_request_template.md` are specified as relative path.
```md
* [ ] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
```

So when someone writing PR clicks it on web UI, Not Found page is shown.

<img width="793" alt=" 2025-05-11 at 14 42 21" src="https://github.com/user-attachments/assets/d94aecf1-5815-445e-b623-9a5bb75b8960" />

Therefore, it seems like the links should be absolute path.

### Related Issues
N/A