### PR TITLE
feat: add a workaround for the rustix crate

### DIFF
--- a/docs/src/cli/generate/workarounds.md
+++ b/docs/src/cli/generate/workarounds.md
@@ -129,3 +129,12 @@ The crates around `wasmtime` and `cranelift`, many but not all of which are publ
 - [`wiggle-generate`](https://crates.io/crates/wiggle-generate)
 - [`wiggle-macro`](https://crates.io/crates/wiggle-macro)
 - [`winx`](https://crates.io/crates/winx)
+
+## `rustix`
+
+The crate `rustix` and its dependency `linux-raw-sys` are triple licensed under `Apache-2.0 WITH LLVM-exception`, `Apache-2.0` and `MIT` licenses.
+However, they also include a `COPYRIGHT` file that confuses `clearlydefined.io` in parsing the license expression. This workaround clarifies the three
+licenses and their inclusion.
+
+- [`rustix`](https://crates.io/crates/rustix)
+- [`linux-raw-sys`](https://crates.io/crates/linux-raw-sys)

--- a/src/licenses/workarounds.rs
+++ b/src/licenses/workarounds.rs
@@ -9,6 +9,7 @@ mod chrono;
 mod clap;
 mod cocoa;
 mod gtk;
+mod linux_raw_sys;
 mod prost;
 mod ring;
 mod rustix;
@@ -93,4 +94,5 @@ const WORKAROUNDS: &[(
     ("unicode-ident", &self::unicode_ident::get),
     ("wasmtime", &self::wasmtime::get),
     ("rustix", &self::rustix::get),
+    ("linux-raw-sys", &self::linux_raw_sys::get),
 ];

--- a/src/licenses/workarounds.rs
+++ b/src/licenses/workarounds.rs
@@ -11,6 +11,7 @@ mod cocoa;
 mod gtk;
 mod prost;
 mod ring;
+mod rustix;
 mod rustls;
 mod sentry;
 mod tonic;
@@ -91,4 +92,5 @@ const WORKAROUNDS: &[(
     ("tract", &self::tract::get),
     ("unicode-ident", &self::unicode_ident::get),
     ("wasmtime", &self::wasmtime::get),
+    ("rustix", &self::rustix::get),
 ];

--- a/src/licenses/workarounds/linux_raw_sys.rs
+++ b/src/licenses/workarounds/linux_raw_sys.rs
@@ -1,0 +1,49 @@
+use super::ClarificationFile;
+use anyhow::Context as _;
+
+pub fn get(krate: &crate::Krate) -> anyhow::Result<Option<super::Clarification>> {
+    if krate.name != "linux-raw-sys" {
+        return Ok(None);
+    }
+
+    Ok(Some(super::Clarification {
+        license: spdx::Expression::parse("(Apache-2.0 WITH LLVM-exception) OR Apache-2.0 OR MIT")
+            .context("failed to parse license expression")?,
+        override_git_commit: None,
+        git: vec![
+            ClarificationFile {
+                path: "LICENSE-APACHE".into(),
+                license: Some(
+                    spdx::Expression::parse("Apache-2.0")
+                        .context("failed to parse license expression")?,
+                ),
+                checksum: "a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2"
+                    .to_owned(),
+                start: None,
+                end: None,
+            },
+            ClarificationFile {
+                path: "LICENSE-MIT".into(),
+                license: Some(
+                    spdx::Expression::parse("MIT").context("failed to parse license expression")?,
+                ),
+                checksum: "23f18e03dc49df91622fe2a76176497404e46ced8a715d9d2b67a7446571cca3"
+                    .to_owned(),
+                start: None,
+                end: None,
+            },
+            ClarificationFile {
+                path: "LICENSE-Apache-2.0_WITH_LLVM-exception".into(),
+                license: Some(
+                    spdx::Expression::parse("LICENSE-Apache-2.0_WITH_LLVM-exception")
+                        .context("failed to parse license expression")?,
+                ),
+                checksum: "268872b9816f90fd8e85db5a28d33f8150ebb8dd016653fb39ef1f94f2686bc5"
+                    .to_owned(),
+                start: None,
+                end: None,
+            },
+        ],
+        files: Vec::new(),
+    }))
+}

--- a/src/licenses/workarounds/rustix.rs
+++ b/src/licenses/workarounds/rustix.rs
@@ -1,0 +1,50 @@
+use super::ClarificationFile;
+use anyhow::Context as _;
+
+pub fn get(krate: &crate::Krate) -> anyhow::Result<Option<super::Clarification>> {
+    if krate.name != "rustix" {
+        return Ok(None);
+    }
+
+    Ok(Some(super::Clarification {
+        license: spdx::Expression::parse("(Apache-2.0 WITH LLVM-exception) OR Apache-2.0 OR MIT")
+            .context("failed to parse license expression")?,
+        override_git_commit: None,
+        git: vec![
+            ClarificationFile {
+                path: "LICENSE-APACHE".into(),
+                license: Some(
+                    spdx::Expression::parse("Apache-2.0")
+                        .context("failed to parse license expression")?,
+                ),
+                checksum: "a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2"
+                    .to_owned(),
+                start: None,
+                end: None,
+            },
+            ClarificationFile {
+                path: "LICENSE-MIT".into(),
+                license: Some(
+                    spdx::Expression::parse("MIT").context("failed to parse license expression")?,
+                ),
+                checksum: "23f18e03dc49df91622fe2a76176497404e46ced8a715d9d2b67a7446571cca3"
+                    .to_owned(),
+                start: None,
+                end: None,
+            },
+            ClarificationFile {
+                path: "LICENSE-Apache-2.0_WITH_LLVM-exception".into(),
+                license: Some(
+                    spdx::Expression::parse("LICENSE-Apache-2.0_WITH_LLVM-exception")
+                        .context("failed to parse license expression")?,
+                ),
+                checksum: "268872b9816f90fd8e85db5a28d33f8150ebb8dd016653fb39ef1f94f2686bc5"
+                    .to_owned(),
+                start: None,
+                end: None,
+            },
+        ],
+        files: Vec::new(),
+    }))
+}
+


### PR DESCRIPTION
Signed-off-by: Ali Sajid Imami <395482+AliSajid@users.noreply.github.com>### Checklist

* [X] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This pull request introduces new license workarounds for the `rustix` and `linux-raw-sys` crates, ensuring proper handling of their multi-license structure and resolving issues with license parsing. The changes include documentation updates, new modules, and logic for license clarification.

### Documentation Updates:

* Added a section in `docs/src/cli/generate/workarounds.md` to describe the licensing details of the `rustix` and `linux-raw-sys` crates, including their triple-license structure and the workaround for parsing issues.

### Code Changes:

#### New License Workaround Modules:
* Added `src/licenses/workarounds/rustix.rs` to handle license clarification for the `rustix` crate. This includes parsing its license expression and associating it with specific license files and checksums.
* Added `src/licenses/workarounds/linux_raw_sys.rs` to handle license clarification for the `linux-raw-sys` crate with similar logic as `rustix`.

#### Integration of New Modules:
* Updated `src/licenses/workarounds.rs` to include the new `rustix` and `linux_raw_sys` modules and registered their license clarification logic in the `WORKAROUNDS` constant. [[1]](diffhunk://#diff-c1ead422f891c52b7e8d77c0feeeb39ab68c73d8b8fc2503e6cdf835fc660dc6R12-R15) [[2]](diffhunk://#diff-c1ead422f891c52b7e8d77c0feeeb39ab68c73d8b8fc2503e6cdf835fc660dc6R96-R97)

### Related Issues

This closes #284 
