### PR TITLE
Add path to parsing error message

### DIFF
--- a/src/licenses/scan.rs
+++ b/src/licenses/scan.rs
@@ -97,7 +97,7 @@ pub(crate) fn check_is_license_file(
                 Ok(expr) => expr,
                 Err(err) => {
                     log::error!(
-                        "failed to parse license '{}' into a valid expression: {err}",
+                        "failed to parse license '{}' at {path:?} into a valid expression: {err}",
                         ided.id.name
                     );
                     return None;
@@ -116,7 +116,7 @@ pub(crate) fn check_is_license_file(
                 Ok(expr) => expr,
                 Err(err) => {
                     log::error!(
-                        "failed to parse license '{}' into a valid expression: {err}",
+                        "failed to parse license '{}' at {path:?} into a valid expression: {err}",
                         ided.id.name
                     );
                     return None;


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](https://github.com/EmbarkStudios/cargo-about/blob/main/CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](https://github.com/EmbarkStudios/cargo-about/blob/main/CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

The error message on it's own is a bit bare. I can barely do anything with the following

```
2026-01-07 13:08:31.885294487 +00:00:00 [ERROR] failed to parse license 'GPL-3.0' into a valid expression: GPL-3.0
^^^^^^^ a deprecated license identifier was used
```

Especially since it doesn't come from my source tree but from a dependency. I tried running `cargo-about` single threaded with the log set to `TRACE` to try to find the file before/after the error message that gives a hint which file is creating the problem, but I'm still not sure if I found the right one.

This commit adds the path of the file that's the reason for this error. The file path should at least include the name of the dependency so one could go there and ask for fixing the license identifier.

### Related Issues

- none I could find