### PR TITLE
fix: surface license text for clarified LicenseRef-* identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 ### Fixed
+- [PR#303](https://github.com/EmbarkStudios/cargo-about/pull/303) now attempts to find and add the license text for `LicenseRef-` licenses the same as it does for licenses in the SPDX list.
 - [PR#304](https://github.com/EmbarkStudios/cargo-about/pull/304) resolved [#194](https://github.com/EmbarkStudios/cargo-about/issues/194) by returning a configuration error when a `clarify` entry specifies neither `files` nor `git`, instead of silently ignoring the clarification.
 - [PR#306](https://github.com/EmbarkStudios/cargo-about/pull/306) resolved [#305](https://github.com/EmbarkStudios/cargo-about/issues/305) by removing the log warnings for using the deprecated fields related to clearly defined which was deprecated/removed in [PR#287](https://github.com/EmbarkStudios/cargo-about/pull/287).
 

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -99,7 +99,7 @@ pub fn generate<'kl>(
 
             let license_iter = resolved.licenses.iter().flat_map(|license| {
                 let mut license_texts = Vec::new();
-                match license.license {
+                match &license.license {
                     spdx::LicenseItem::Spdx { id, .. } => {
                         // Attempt to retrieve the actual license file from the crate, note that in some cases
                         // _sigh_ there are actually multiple license texts for the same license with different
@@ -111,7 +111,7 @@ pub fn generate<'kl>(
                                 // Check if this is the actual license file we want
                                 if !lf
                                     .license_expr
-                                    .evaluate(|ereq| ereq.license.id() == Some(id))
+                                    .evaluate(|ereq| ereq.license.id() == Some(*id))
                                 {
                                     return None;
                                 }
@@ -151,11 +151,56 @@ pub fn generate<'kl>(
                             });
                         }
                     }
-                    spdx::LicenseItem::Other { .. } => {
-                        log::warn!(
-                            "{license} has no license file for crate '{}'",
-                            krate_license.krate
-                        );
+                    spdx::LicenseItem::Other(license_ref) => {
+                        // LicenseRef-* identifiers are project-specific by
+                        // definition (askalono's SPDX corpus can never
+                        // contain them), but a clarification (or a future
+                        // REUSE-aware filename heuristic) may have
+                        // populated `license_files` with the actual text.
+                        // Mirror the Spdx arm's filter so consumers get
+                        // the bundled text instead of an empty section.
+                        license_texts.extend(krate_license
+                            .license_files
+                            .iter()
+                            .filter_map(|lf| {
+                                if !lf.license_expr.evaluate(|ereq| {
+                                    matches!(
+                                        &ereq.license,
+                                        spdx::LicenseItem::Other(other)
+                                            if other.as_ref() == license_ref.as_ref()
+                                    )
+                                }) {
+                                    return None;
+                                }
+
+                                match &lf.kind {
+                                    licenses::LicenseFileKind::Text(text)
+                                    | licenses::LicenseFileKind::AddendumText(text, _) => {
+                                        let id_str = license_ref.to_string();
+                                        Some(License {
+                                            name: id_str.clone(),
+                                            id: id_str,
+                                            text: text.clone(),
+                                            source_path: Some(lf.path.clone()),
+                                            used_by: Vec::new(),
+                                            first_of_kind: false,
+                                        })
+                                    }
+                                    licenses::LicenseFileKind::Header => None,
+                                }
+                            }));
+
+                        if license_texts.is_empty() {
+                            // No canonical-text fallback (unlike the Spdx
+                            // arm) — there's no canonical text for a
+                            // project-specific LicenseRef-*. Surface the
+                            // warning so the consumer knows their bundle
+                            // is incomplete and they need to clarify.
+                            log::warn!(
+                                "{license} has no license file for crate '{}'",
+                                krate_license.krate
+                            );
+                        }
                     }
                 }
 


### PR DESCRIPTION
Disclosure: I used LLMs to trace, fix, and check this patch while debugging semi-related warnings when using slint.

Perhaps we could also expand this if theirs interest in any REUSE-aware filename heuristic development as well.

---

### Checklist

* [x] I have read the [Contributor Guide](https://github.com/EmbarkStudios/cargo-about/blob/main/CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](https://github.com/EmbarkStudios/cargo-about/blob/main/CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

`generate.rs`'s per-license iteration treated the two `LicenseItem` variants asymmetrically. The `Spdx { id, .. }` arm filters `krate_license.license_files` for entries whose recorded expression matches the SPDX id and uses the file's text. The `Other(..)` arm unconditionally emitted `log::warn!("{license} has no license file for crate '{}'")` and never looked at `license_files` at all.

That meant clarifications targeting a `LicenseRef-*` identifier (e.g. `[<crate>.clarify]` with `license =
"LicenseRef-Slint-Royalty-free-2.0"` and a `[[<crate>.clarify.files]]` pointing at the bundled license file) ran successfully — `apply_ clarification` populated `license_files` correctly, the DEBUG log confirmed `applying clarification expression '...'` — but the generated bundle had an empty section header for the LicenseRef license and the warning still surfaced. There was no way to make the bundle complete without falling back to a Handlebars-side template hack.

The `Other` arm now mirrors the `Spdx` arm's filter:

  - Iterate `license_files`, keep entries whose `license_expr` contains a `LicenseItem::Other` matching the outer LicenseRef (compared via `LicenseRef::PartialEq`, which honors both the optional `doc_ref` and the `lic_ref`).
  - For text-bearing files, push a `License` entry using the LicenseRef's `Display` form for both `name` and `id`.
  - Emit the existing warning only when no match is found. There's no canonical-text fallback for project-specific LicenseRefs (no equivalent of `LicenseId::text()`), so behavior in the no-match case is unchanged from before.

The surrounding `match license.license` becomes `match &license.license` so the new arm can bind `license_ref: &Box<LicenseRef>` without moving out of the `LicenseReq`. The `Spdx` arm's `id` binding becomes a reference too; the only adjustment is dereferencing `*id` inside `evaluate`'s closure.

Concrete real-world impact: bundlers consuming Slint can now clarify their LicenseRef-Slint-Royalty-free-2.0 election and get the actual license text in their generated attribution, instead of a textless section + per-crate warning. The same applies to any project using a LicenseRef-* identifier (REUSE-compliant projects hosted in non-SPDX-blessed corners of the ecosystem; Embark's own about.toml example for `ring` only happens to work today because ring's clarified license is `OpenSSL` — a real SPDX id).

### Related Issues

- https://github.com/slint-ui/slint/pull/11631