### PR TITLE
Error when a clarify entry has no files or git source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- Resolved [#194](https://github.com/EmbarkStudios/cargo-about/issues/194) by returning a configuration error when a `clarify` entry specifies neither `files` nor `git`, instead of silently ignoring the clarification.
+
 ## [0.9.0] - 2026-04-24
 ### Changed
 - [PR#299](https://github.com/EmbarkStudios/cargo-about/pull/299) updated dependencies

--- a/src/licenses/config.rs
+++ b/src/licenses/config.rs
@@ -162,12 +162,28 @@ pub struct Clarification {
 
 impl<'de> Deserialize<'de> for Clarification {
     fn deserialize(value: &mut Value<'de>) -> Result<Self, toml_span::DeserError> {
+        let span = value.span;
         let mut tab = de::TableHelper::new(value)?;
 
         let license = parse_expr(&mut tab, "license")?;
         let override_git_commit = tab.optional("override-git-commit");
-        let files = tab.optional("files").unwrap_or_default();
-        let git = tab.optional("git").unwrap_or_default();
+        let files: Vec<ClarificationFile> = tab.optional("files").unwrap_or_default();
+        let git: Vec<ClarificationFile> = tab.optional("git").unwrap_or_default();
+
+        // A clarification needs at least one source of truth (`files` or `git`)
+        // for the checksums it validates against. Without one, the clarification
+        // can never be applied and would be silently ignored at generation time,
+        // falling back to concatenating all discovered licenses. Reject it here
+        // so the misconfiguration is reported instead of quietly dropped (#194).
+        if files.is_empty() && git.is_empty() {
+            tab.errors.push(toml_span::Error {
+                kind: toml_span::ErrorKind::Custom(
+                    "a `clarify` entry must specify at least one of `files` or `git` as the source of truth for its license expression".into(),
+                ),
+                span,
+                line_info: None,
+            });
+        }
 
         tab.finalize(None)?;
 
@@ -395,5 +411,83 @@ impl<'de> Deserialize<'de> for Config {
             workarounds,
             crates,
         })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Config;
+    use toml_span::Deserialize;
+
+    fn deserialize(s: &str) -> Result<Config, toml_span::DeserError> {
+        let mut value = toml_span::parse(s).expect("failed to parse toml");
+        Config::deserialize(&mut value)
+    }
+
+    /// A clarification that specifies neither `files` nor `git` has no source of
+    /// truth, so it can never be applied. It must be rejected at config parse
+    /// time rather than silently ignored (see issue #194).
+    #[test]
+    fn rejects_clarification_without_source() {
+        let err = match deserialize(
+            r#"
+accepted = ["MIT"]
+
+[some-crate.clarify]
+license = "MIT AND Apache-2.0"
+"#,
+        ) {
+            Ok(_) => panic!("a clarification without `files` or `git` should be an error"),
+            Err(err) => err,
+        };
+
+        let msg = err
+            .errors
+            .iter()
+            .map(|e| e.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            msg.contains("files") && msg.contains("git"),
+            "error should mention the required `files`/`git` source, got: {msg}"
+        );
+    }
+
+    /// A clarification that supplies `files` is a valid source and must keep
+    /// parsing successfully.
+    #[test]
+    fn accepts_clarification_with_files() {
+        deserialize(
+            r#"
+accepted = ["MIT"]
+
+[some-crate.clarify]
+license = "MIT"
+
+[[some-crate.clarify.files]]
+path = "LICENSE"
+checksum = "0000000000000000000000000000000000000000000000000000000000000000"
+"#,
+        )
+        .expect("a clarification with `files` should parse");
+    }
+
+    /// A clarification that supplies `git` is a valid source and must keep
+    /// parsing successfully.
+    #[test]
+    fn accepts_clarification_with_git() {
+        deserialize(
+            r#"
+accepted = ["MIT"]
+
+[some-crate.clarify]
+license = "MIT"
+
+[[some-crate.clarify.git]]
+path = "LICENSE"
+checksum = "0000000000000000000000000000000000000000000000000000000000000000"
+"#,
+        )
+        .expect("a clarification with `git` should parse");
     }
 }


### PR DESCRIPTION
Fixes #194

### Problem

A `clarify` entry that supplies a `license` expression but no source of truth (neither `files` nor `git`) currently parses without complaint. At generation time it can never be applied: `apply_clarification` has an internal `anyhow::ensure!(!files.is_empty() || !git.is_empty(), ...)`, and `gather_clarified` only surfaces that failure as a `log::warn!` before dropping the clarification. License discovery then silently falls back to concatenating every license it found, which is exactly the confusing behaviour described in #193 and #194.

### Fix

Validate the requirement at config parse time. In `Clarification::deserialize`, after reading `files` and `git`, if both are empty a clear error is pushed onto the table's error list pointing at the offending `[crate.clarify]` table:

```
a `clarify` entry must specify at least one of `files` or `git` as the
source of truth for its license expression
```

Clarifications that supply either `files` or `git` keep parsing as before, so no valid configuration shape is affected. The runtime `ensure!` in `apply_clarification` is left in place as defense in depth.

### Reproduction / before and after

Added unit tests in `src/licenses/config.rs` that drive the real `Config::deserialize` path.

Before the fix, a source-less clarify parsed successfully, so `rejects_clarification_without_source` failed:

```
test licenses::config::test::rejects_clarification_without_source ... FAILED
test licenses::config::test::accepts_clarification_with_files ... ok
test licenses::config::test::accepts_clarification_with_git ... ok
```

After the fix all three pass:

```
test licenses::config::test::rejects_clarification_without_source ... ok
test licenses::config::test::accepts_clarification_with_files ... ok
test licenses::config::test::accepts_clarification_with_git ... ok
```

The error case is this config:

```toml
accepted = ["MIT"]

[some-crate.clarify]
license = "MIT AND Apache-2.0"
```

while a clarify with `[[some-crate.clarify.files]]` or `[[some-crate.clarify.git]]` continues to parse.

`cargo build`, `cargo clippy --all-targets`, and `cargo test --lib` are all green. A CHANGELOG entry was added under `[Unreleased]`.
