### PR TITLE
Update CI images to macos-15 and windows-2025

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -35,7 +35,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-14, windows-2022]
+        os: [ubuntu-24.04, macos-15, windows-2025]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -133,13 +133,11 @@ jobs:
           - os: ubuntu-24.04
             target: aarch64-unknown-linux-musl
             container: ghcr.io/cross-rs/aarch64-unknown-linux-musl:edge
-          - os: windows-2022
+          - os: windows-2025
             target: x86_64-pc-windows-msvc
-          - os: windows-2022
+          - os: windows-2025
             target: aarch64-pc-windows-msvc
-          - os: macOS-13
-            target: x86_64-apple-darwin
-          - os: macOS-14
+          - os: macOS-15
             target: aarch64-apple-darwin
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -48,11 +48,11 @@ jobs:
         shell: bash
         run: cargo test --release --features cli
       - name: detects powershell
-        if: ${{ matrix.os != 'macos-14' }}
+        if: ${{ matrix.os != 'macos-15' }}
         shell: pwsh
         run: cargo test --release --features cli -- --ignored is_powershell_true
       - name: doesn't detect powershell
-        if: ${{ matrix.os != 'macos-14' }}
+        if: ${{ matrix.os != 'macos-15' }}
         shell: bash
         run: cargo test --release --features cli -- --ignored is_powershell_false
 


### PR DESCRIPTION
Also removes publishing of `x86_64-apple-darwin` binaries for releases, can be added back via macos-15-intel runner in the future if someone actually needs it, but I'm sort of inclined to just tell people to build it themselves if they need niche platforms like that.