### PR TITLE
fix(tests): resolve cargo-about binary for release/debug builds

### DIFF
--- a/tests/utils/cargo_about.rs
+++ b/tests/utils/cargo_about.rs
@@ -11,7 +11,7 @@ pub struct CargoAbout {
 
 impl CargoAbout {
     pub fn new(package: &Package) -> Result<Self> {
-        let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!());
+        let mut cmd = Command::new(assert_cmd::cargo::cargo_bin("cargo-about"));
         cmd.current_dir(&package.dir);
         cmd.arg("--color=never");
         Ok(CargoAbout { cmd })


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](https://github.com/EmbarkStudios/cargo-about/blob/main/CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](https://github.com/EmbarkStudios/cargo-about/blob/main/CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This PR makes it possible to run the test via either debug or release binary.

Previously I was getting:

```
  Failed to spawn cd "/tmp/.tmpBJCwHH" && ".../target/debug/cargo-about" "--color=never" "generate" "about.hbs":
  No such file or directory (os error 2)
```

Because the debug binary did not exist (I only built with `--release` flag).
With these changes, it's now possible to `cargo test --release --features cli --test all` 

P.S. Ran into this while updating the [Arch package](https://archlinux.org/packages/extra/x86_64/cargo-about/).


### Related Issues

n/a